### PR TITLE
updated profile.handlebars

### DIFF
--- a/views/profile.handlebars
+++ b/views/profile.handlebars
@@ -34,9 +34,9 @@
         </div>
       </form>
     </div>
-    {{#if events.length}}
     <div class="col-md-6 event-list mt-2">
       <h3>My Events:</h3>
+      {{#if events.length}}
       {{#each events as |event|}}
       <div class="row mt-4">
         <div class="col-md-8">
@@ -52,6 +52,8 @@
       </div>
       {{/each}}
     </div>
+    {{else}}
+    <p class="my-4">No created events</p>
     {{/if}}
   </div>
 </div>


### PR DESCRIPTION
profile page now shows the text: "No created events" when there are no events created by the user instead of having a blank/empty section next to the form (which I thought was somewhat unintuitive. Ideally the form to create an event should be on its own self contained page, similar to updating/editing an event - plans for future development)